### PR TITLE
Kubernetes networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+
+(⎈ |minikube:default)➜  canary git:(kubernetes-networks) ✗ for i in $(seq 1 10); do curl -s http://lb-ingress.local/web/index.html | grep 172; sleep 1; done
+172.17.0.8	canary-7ff7869755-kfnph</pre>
+172.17.0.6	production-5f968785b5-j8b6b</pre>
+172.17.0.5	canary-7ff7869755-m56jm</pre>
+172.17.0.6	production-5f968785b5-j8b6b</pre>
+172.17.0.6	canary-7ff7869755-2d79v</pre>
+172.17.0.7	production-5f968785b5-jtkr8</pre>
+172.17.0.5	production-5f968785b5-brjlx</pre>
+172.17.0.7	production-5f968785b5-jtkr8</pre>
+172.17.0.6	production-5f968785b5-j8b6b</pre>
+172.17.0.5	canary-7ff7869755-m56jm</pre>
+
 # Выполнено ДЗ №3
 
  - [x] Основное ДЗ

--- a/README.md
+++ b/README.md
@@ -1,3 +1,101 @@
+# Выполнено Д4 №1
+
+ - [x] Основное ДЗ
+ - [x] Задание со *
+
+## В процессе сделано:
+
+Перейдем сразу к звездам.
+
+Впрочем, на тему "livenessProbe с прверкой запуска процесса" - технически возможно, но на мой взгляд смыста не имеет, так как, обычно, от процесса требуется чуть больше, чем просто его запуск.
+
+### DNS через MetalLB
+
+Для работы DNS на необходимо обеспечить обращение к назначенному адресу по протоколам TCP и UDP. Так как MetalLB не умеет в мультипротоколы, воспользуемся его возможностью делить один IP между несколькими сервисами.
+
+Это достигается при помощи аннотации:
+```
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns--primary
+```
+
+Если у двух сервисов указывается одиноковый ключ (тут это - dns--primary), то два сервиса получают один и тот же IP.
+```
+kube-system            out-dns-tcp                          LoadBalancer   10.111.145.71   172.17.255.2   53:30069/TCP                 29h
+kube-system            out-dns-udp                          LoadBalancer   10.102.155.94   172.17.255.2   53:30045/UDP                 29h
+```
+
+```
+$ nslookup kubernetes.default.svc.cluster.local 172.17.255.2
+Server:		172.17.255.2
+Address:	172.17.255.2#53
+
+Name:	kubernetes.default.svc.cluster.local
+Address: 10.96.0.1
+```
+
+### Ingress для Dashboard
+
+Так как dashboard-у требуется https, добавим в настройку ingress-а аннотацию:
+```
+nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+```
+
+Дополнительно добавим блок, отвечающий за корректное формирование адресной строки (нам нужно добавлять к /dashboard, то, что будет динамически сформировано при работе с бордой):
+```
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^(/dashboard)$ $1/ permanent;
+      rewrite "(?i)/dashboard(/|$)(.*)" /$2 break;
+```
+
+После чего можем обращаться к dashboard по адресу (не забудем добавить lb-ingress.local в /etc/hosts)
+https://lb-ingress.local/dashboard
+```
+$ curl -kL https://lb-ingress.local/dashboard
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Kubernetes Dashboard</title>
+  <link rel="icon"
+        type="image/png"
+        href="assets/images/kubernetes-logo.png" />
+  <meta name="viewport"
+        content="width=device-width">
+<link rel="stylesheet" href="styles.d8a1833bf9631b49f8ae.css"></head>
+
+<body>
+  <kd-root></kd-root>
+<script src="runtime.a3c2fb5c390e8fb10577.js" defer></script><script src="polyfills-es5.ddf623b9f96429e29863.js" nomodule defer></script><script src="polyfills.24a7a4821c30c3b30717.js" defer></script><script src="scripts.391d299173602e261418.js" defer></script><script src="main.a0d83b15387cfc420c65.js" defer></script></body>
+
+</html>
+```
+
+### Canary для Ingress
+
+Опять же воспользуемся аннотациями, предназначенными именно для распределения потоков трафика.
+```
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "50"
+```
+
+Проверим, таким ли будет распределение:
+```
+$ for i in $(seq 1 10); do curl -s http://lb-ingress.local/web/index.html | grep 172; done
+172.17.0.5	canary-7ff7869755-m56jm</pre>
+172.17.0.6	canary-7ff7869755-2d79v</pre>
+172.17.0.5	production-5f968785b5-brjlx</pre>
+172.17.0.7	production-5f968785b5-jtkr8</pre>
+172.17.0.5	canary-7ff7869755-m56jm</pre>
+172.17.0.8	canary-7ff7869755-kfnph</pre>
+172.17.0.6	production-5f968785b5-j8b6b</pre>
+172.17.0.6	canary-7ff7869755-2d79v</pre>
+172.17.0.8	canary-7ff7869755-kfnph</pre>
+172.17.0.5	production-5f968785b5-brjlx</pre>
+```
+
+В общем - примерно то, что и ожидали. Не забываем, что речь идет о вероятности.
 
 (⎈ |minikube:default)➜  canary git:(kubernetes-networks) ✗ for i in $(seq 1 10); do curl -s http://lb-ingress.local/web/index.html | grep 172; sleep 1; done
 172.17.0.8	canary-7ff7869755-kfnph</pre>

--- a/kubernetes-networks/canary/canary-ingress.yaml
+++ b/kubernetes-networks/canary/canary-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: canary
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "30"
+spec:
+  rules:
+  - host: lb-ingress.local
+    http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: canary
+          servicePort: 8000

--- a/kubernetes-networks/canary/canary-ingress.yaml
+++ b/kubernetes-networks/canary/canary-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "30"
+    nginx.ingress.kubernetes.io/canary-weight: "50"
 spec:
   rules:
   - host: lb-ingress.local

--- a/kubernetes-networks/canary/canary.yaml
+++ b/kubernetes-networks/canary/canary.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: canary
+spec:
+  selector:
+    app: canary
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: canary
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: canary
+  template:
+    metadata:
+      labels:
+        app: canary
+    spec:
+      containers:
+      - name: web
+        image: soaron/web:2.0
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      initContainers:
+        - name: html-gen
+          image: busybox:musl
+          command: ['sh', '-c', 'wget -O- https://bit.ly/otus-k8s-index-gen | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/canary/production-ingress.yaml
+++ b/kubernetes-networks/canary/production-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: lb-ingress.local
+    http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: production
+          servicePort: 8000

--- a/kubernetes-networks/canary/production.yaml
+++ b/kubernetes-networks/canary/production.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: production
+spec:
+  selector:
+    app: production
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: production
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: production
+  template:
+    metadata:
+      labels:
+        app: production
+    spec:
+      containers:
+      - name: web
+        image: soaron/web:1.0
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      initContainers:
+        - name: html-gen
+          image: busybox:musl
+          command: ['sh', '-c', 'wget -O- https://bit.ly/otus-k8s-index-gen | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/coredns/out-dns-tcp.yaml
+++ b/kubernetes-networks/coredns/out-dns-tcp.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns--primary
+  name: out-dns-tcp
+  namespace: kube-system
+spec:
+  type: LoadBalancer
+  ports:
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+
+

--- a/kubernetes-networks/coredns/out-dns-udp.yaml
+++ b/kubernetes-networks/coredns/out-dns-udp.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns--primary
+  name: out-dns-udp
+  namespace: kube-system
+spec:
+  type: LoadBalancer
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+
+

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/secure-backends: "true"
+    ingress.kubernetes.io/ssl-passthrough: "false"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^(/dashboard)$ $1/ permanent;
+      rewrite "(?i)/dashboard(/|$)(.*)" /$2 break;
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard(/|$)(.*)
+        backend:
+          serviceName: kubernetes-dashboard
+          servicePort: 443

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -2,18 +2,17 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: kubernetes-dashboard
-  namespace: kubernetes-dashboard
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/secure-backends: "true"
-    ingress.kubernetes.io/ssl-passthrough: "false"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       rewrite ^(/dashboard)$ $1/ permanent;
       rewrite "(?i)/dashboard(/|$)(.*)" /$2 break;
+  namespace: kubernetes-dashboard
 spec:
   rules:
-  - http:
+  - host: lb-ingress.local
+    http:
       paths:
       - path: /dashboard(/|$)(.*)
         backend:

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 172.17.255.1-172.17.255.255 

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/test.yml
+++ b/kubernetes-networks/test.yml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-udp-svc-lb
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+    - protocol: UDP
+      port: 53
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-tcp-svc-lb
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 53
+      name: tcp-first
+    - protocol: TCP
+      port: 9153
+      name: tcp-second

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: soaron/web:1.0
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      initContainers:
+        - name: html-gen
+          image: busybox:musl
+          command: ['sh', '-c', 'wget -O- https://bit.ly/otus-k8s-index-gen | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено Д4 №1

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:

Перейдем сразу к звездам.

Впрочем, на тему "livenessProbe с прверкой запуска процесса" - технически возможно, но на мой взгляд смыста не имеет, так как, обычно, от процесса требуется чуть больше, чем просто его запуск.

### DNS через MetalLB

Для работы DNS на необходимо обеспечить обращение к назначенному адресу по протоколам TCP и UDP. Так как MetalLB не умеет в мультипротоколы, воспользуемся его возможностью делить один IP между несколькими сервисами.

Это достигается при помощи аннотации:
```
  annotations:
    metallb.universe.tf/allow-shared-ip: dns--primary
```

Если у двух сервисов указывается одиноковый ключ (тут это - dns--primary), то два сервиса получают один и тот же IP.
```
kube-system            out-dns-tcp                          LoadBalancer   10.111.145.71   172.17.255.2   53:30069/TCP                 29h
kube-system            out-dns-udp                          LoadBalancer   10.102.155.94   172.17.255.2   53:30045/UDP                 29h
```

```
$ nslookup kubernetes.default.svc.cluster.local 172.17.255.2
Server:		172.17.255.2
Address:	172.17.255.2#53

Name:	kubernetes.default.svc.cluster.local
Address: 10.96.0.1
```

### Ingress для Dashboard

Так как dashboard-у требуется https, добавим в настройку ingress-а аннотацию:
```
nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
```

Дополнительно добавим блок, отвечающий за корректное формирование адресной строки (нам нужно добавлять к /dashboard, то, что будет динамически сформировано при работе с бордой):
```
    nginx.ingress.kubernetes.io/configuration-snippet: |
      rewrite ^(/dashboard)$ $1/ permanent;
      rewrite "(?i)/dashboard(/|$)(.*)" /$2 break;
```

После чего можем обращаться к dashboard по адресу (не забудем добавить lb-ingress.local в /etc/hosts)
https://lb-ingress.local/dashboard
```
$ curl -kL https://lb-ingress.local/dashboard
<!doctype html>
<html lang="en">

<head>
  <meta charset="utf-8">
  <title>Kubernetes Dashboard</title>
  <link rel="icon"
        type="image/png"
        href="assets/images/kubernetes-logo.png" />
  <meta name="viewport"
        content="width=device-width">
<link rel="stylesheet" href="styles.d8a1833bf9631b49f8ae.css"></head>

<body>
  <kd-root></kd-root>
<script src="runtime.a3c2fb5c390e8fb10577.js" defer></script><script src="polyfills-es5.ddf623b9f96429e29863.js" nomodule defer></script><script src="polyfills.24a7a4821c30c3b30717.js" defer></script><script src="scripts.391d299173602e261418.js" defer></script><script src="main.a0d83b15387cfc420c65.js" defer></script></body>

</html>
```

### Canary для Ingress

Опять же воспользуемся аннотациями, предназначенными именно для распределения потоков трафика.
```
    nginx.ingress.kubernetes.io/canary: "true"
    nginx.ingress.kubernetes.io/canary-weight: "50"
```

Проверим, таким ли будет распределение:
```
$ for i in $(seq 1 10); do curl -s http://lb-ingress.local/web/index.html | grep 172; done
172.17.0.5	canary-7ff7869755-m56jm</pre>
172.17.0.6	canary-7ff7869755-2d79v</pre>
172.17.0.5	production-5f968785b5-brjlx</pre>
172.17.0.7	production-5f968785b5-jtkr8</pre>
172.17.0.5	canary-7ff7869755-m56jm</pre>
172.17.0.8	canary-7ff7869755-kfnph</pre>
172.17.0.6	production-5f968785b5-j8b6b</pre>
172.17.0.6	canary-7ff7869755-2d79v</pre>
172.17.0.8	canary-7ff7869755-kfnph</pre>
172.17.0.5	production-5f968785b5-brjlx</pre>
```

В общем - примерно то, что и ожидали. Не забываем, что речь идет о вероятности.

$ for i in $(seq 1 10); do curl -s http://lb-ingress.local/web/index.html | grep 172; sleep 1; done
172.17.0.8	canary-7ff7869755-kfnph</pre>
172.17.0.6	production-5f968785b5-j8b6b</pre>
172.17.0.5	canary-7ff7869755-m56jm</pre>
172.17.0.6	production-5f968785b5-j8b6b</pre>
172.17.0.6	canary-7ff7869755-2d79v</pre>
172.17.0.7	production-5f968785b5-jtkr8</pre>
172.17.0.5	production-5f968785b5-brjlx</pre>
172.17.0.7	production-5f968785b5-jtkr8</pre>
172.17.0.6	production-5f968785b5-j8b6b</pre>
172.17.0.5	canary-7ff7869755-m56jm</pre>
```